### PR TITLE
Trim Null Padded Variable Names

### DIFF
--- a/src/Curiosity.SPSS/FileParser/Records/EncodingExtensions.cs
+++ b/src/Curiosity.SPSS/FileParser/Records/EncodingExtensions.cs
@@ -9,7 +9,7 @@ namespace Curiosity.SPSS.FileParser.Records
     internal static class EncodingExtensions
     {
         /// <summary>
-        /// Gets a decoded string, with trailing spaces trimmed out
+        /// Gets a decoded string, with trailing spaces and null characters trimmed out
         /// </summary>
         internal static string GetTrimmed(this Encoding enc, byte[] arr)
         {
@@ -23,7 +23,7 @@ namespace Curiosity.SPSS.FileParser.Records
                 throw new ArgumentNullException(nameof(arr));
             }
 
-            return enc.GetString(arr).TrimEnd();
+            return enc.GetString(arr).TrimEnd('\0').TrimEnd();
         }
 
 


### PR DESCRIPTION
As referenced from https://github.com/siisltd/Curiosity.SPSS/issues/2 ...

Popular sources for SPSS files pad variable names with null characters instead of spaces.  (specifically Qualtrics) This extra condition fixes the long name lookup for files that use this convention.